### PR TITLE
DOI are now handled by Citoid

### DIFF
--- a/lookup.php
+++ b/lookup.php
@@ -328,7 +328,9 @@ switch($k[0]) {
 		$class = 'CitoidLookup';
 		break;
 	case 'doi':
-		$class = 'DOILookup';
+		// we use CitoidLookup for DOIs
+		// in order to have the same behavior between the Visual Editor (only based on Citoid) and the Source Editor
+		$class = 'CitoidLookup';
 		break;
 	case 'url':
 		$class = 'CitoidLookup';


### PR DESCRIPTION
When resolving DOIs, there are some very confusing cases for which reftoolbar (source editor) and Citoid (visual editor) have different behaviors.

In particular, it seems that Citoid is better:
* reftoolbar finds nothing: https://tools.wmflabs.org/reftoolbar/lookup.php?doi=10.1109%2fASE.2011.6100076&template=journal&format=ref
* while Citoid has the correct answer: https://en.wikipedia.org/api/rest_v1/data/citation/mediawiki/10.1109%2fASE.2011.6100076?action=query&format=json

This Pull-Request unifies the backend: lookup.php also uses Citoid for DOI queries. 